### PR TITLE
Update .gitignore to add normal venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+venv/
 __pycache__/
 *.rdvgame
 


### PR DESCRIPTION
A really old standard is to use `venv` over `.venv`.