### PR TITLE
Use native file picker

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -49,10 +49,10 @@ class MainWindow(QtWidgets.QMainWindow):
         file_dialog.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFiles)
         file_dialog.setNameFilter("Randovania Game (*.rdvgame)")
         file_dialog.exec()
-        file = file_dialog.selectedFiles()
-        if file[0] == '':
+        files = file_dialog.selectedFiles()
+        if len(files) == 0:
             return
-        self.load_file(file[0])
+        self.load_file(files[0])
         
     def load_file(self, file):
         spoiler = SpoilerFile()

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -45,7 +45,11 @@ class MainWindow(QtWidgets.QMainWindow):
             self.load_file(file)
         
     def load_file_dialog(self):
-        file = QtWidgets.QFileDialog.getOpenFileName(self, "Load file...", filter="Randovania Game (*.rdvgame)")
+        file_dialog = QtWidgets.QFileDialog(self)
+        file_dialog.setFileMode(QtWidgets.QFileDialog.FileMode.ExistingFiles)
+        file_dialog.setNameFilter("Randovania Game (*.rdvgame)")
+        file_dialog.exec()
+        file = file_dialog.selectedFiles()
         if file[0] == '':
             return
         self.load_file(file[0])


### PR DESCRIPTION
Closes #20 

This changes getOpenFileName for an implementation like any other widget.

Checking if the picker is still Qt instead of native is appreciated