### PR TITLE
Revert "Disable automatic CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@
 
 name: CI
 
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
 jobs:
   mypy:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
Reverts Naii-the-Baf/rdv-spoiler-log-parser#85

The workflow was disabled; there's no need to break the file now.