### PR TITLE
More linter fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,6 @@ repos:
     rev: v0.11.12
     hooks:
     -   id: ruff-check
-        args: [ --no-fix, --diff ]
+        args: [ --fix ]
     -   id: ruff-format 
-        args: [ --check, --diff ]
+        args: [ --check ]


### PR DESCRIPTION
`--no-fix` should be `--fix` instead. Also removes diff so command prompts don't fill up with garbage